### PR TITLE
Version compatibility issue fixed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "illuminate/support": "~5.1",
-        "php" : "~5.6|~7.0"
+        "php" : ">=5.6"
     },
     "require-dev": {
         "phpunit/phpunit" : "~4.0||~5.0||~6.0",


### PR DESCRIPTION
Whenever a user tries to install via `composer` it gets an error because of the specified versions. Version is removed so that it works on php >= 5.6